### PR TITLE
Support Non-4/4 Time Signatures and Variable Time Signatures (no UI)

### DIFF
--- a/8beatMap/Form1.cs
+++ b/8beatMap/Form1.cs
@@ -370,6 +370,11 @@ namespace _8beatMap
             chart.Length = NewLen;
             ResizeScrollbar();
             SetCurrTick(CurrentTick);
+
+            Notedata.TimeSigChange lastticktimesig = chart.GetTimeSigForTick(chart.Length - 1);
+            //ResizeBox.Value = chart.Length / 48;
+            ResizeBox.Value = lastticktimesig.StartBar + (chart.Length - lastticktimesig.StartTick) / (lastticktimesig.Numerator * 48 / lastticktimesig.Denominator); // bar of last timesig change + ticks left in chart / ticks in a bar
+
             UpdateChart();
         }
 

--- a/8beatMap/Form1.cs
+++ b/8beatMap/Form1.cs
@@ -423,7 +423,11 @@ namespace _8beatMap
                     SkinnedMessageBox.Show(skin, DialogResMgr.GetString("ChartLoadNoBPM"), "", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     chart.BPM = 120;
                 }
-                ResizeBox.Value = chart.Length / 48;
+
+                Notedata.TimeSigChange lastticktimesig = chart.GetTimeSigForTick(chart.Length - 1);
+                //ResizeBox.Value = chart.Length / 48;
+                ResizeBox.Value = lastticktimesig.StartBar + (chart.Length - lastticktimesig.StartTick) / (lastticktimesig.Numerator * 48 / lastticktimesig.Denominator); // bar of last timesig change + ticks left in chart / ticks in a bar
+
                 BPMbox.Value = (decimal)chart.BPM;
                 ResizeScrollbar();
                 SetCurrTick(0);
@@ -819,7 +823,14 @@ namespace _8beatMap
 
         private void ResizeBtn_Click(object sender, EventArgs e)
         {
-            ResizeChart((int)ResizeBox.Value * 48);
+            Notedata.TimeSigChange lastticktimesig = chart.GetTimeSigForTick(chart.Length - 1);
+            while (lastticktimesig.StartBar > (int)ResizeBox.Value) // just skip bars we don't care about
+            {
+                lastticktimesig = chart.GetTimeSigForTick(lastticktimesig.StartTick - 1);
+            }
+
+            //ResizeChart((int)ResizeBox.Value * 48);
+            ResizeChart(lastticktimesig.StartTick + ((int)ResizeBox.Value - lastticktimesig.StartBar) * (lastticktimesig.Numerator * 48 / lastticktimesig.Denominator)); // tick last timesig change is at + how many extra bars after that * bar length
             UpdateChart();
         }
 

--- a/8beatMap/Form1.cs
+++ b/8beatMap/Form1.cs
@@ -172,7 +172,9 @@ namespace _8beatMap
                 if (i >= chart.Length) break;
                 if (i < 0) i = 0;
 
-                if (i % 48 == 0)
+                Notedata.TimeSigChange timesig = chart.GetTimeSigForTick(i);
+
+                if ((i - timesig.StartTick) % (timesig.Numerator * 48 / timesig.Denominator) == 0)
                 {
                     Grfx.FillRectangle(BarLineBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 2, width, 1);
                 }
@@ -225,16 +227,16 @@ namespace _8beatMap
 
                 if (!NoGrid)
                 {
-                    if (i % 48 == 0)
+                    if ((i - timesig.StartTick) % (timesig.Numerator * 48 / timesig.Denominator) == 0) // bars
                     {
                         Grfx.FillRectangle(BarLineBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 3, width, 3);
                         if (!DrawBarNumsAfter) Grfx.DrawString((i / 48 + 1).ToString(), BarNumFont, BarTextBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 4 - (int)Math.Round(BarNumSize));
                     }
-                    else if (i % 12 == 0)
+                    else if ((i - timesig.StartTick) % (48 / timesig.Denominator) == 0) // notes of denominator length -- 48 = one whole note (four quarters)
                     {
                         Grfx.FillRectangle(QuarterLineBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 2, width, 1);
                     }
-                    else if (i % 6 == 0)
+                    else if ((i - timesig.StartTick) % (24 / timesig.Denominator) == 0) // notes of half denominator length
                     {
                         Grfx.FillRectangle(EigthLineBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 2, width, 1);
                     }
@@ -248,7 +250,9 @@ namespace _8beatMap
                     if (i >= chart.Length) break;
                     if (i < 0) i = 0;
 
-                    if (i % 48 == 0)
+                    Notedata.TimeSigChange timesig = chart.GetTimeSigForTick(i);
+
+                    if ((i - timesig.StartTick) % (timesig.Numerator * 48 / timesig.Denominator) == 0)
                     {
                         // draw bar number after all notes to avoid rendering issue when over holds
                         Grfx.DrawString((i / 48 + 1).ToString(), BarNumFont, BarTextBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 4 - (int)Math.Round(BarNumSize));

--- a/8beatMap/Form1.cs
+++ b/8beatMap/Form1.cs
@@ -230,7 +230,7 @@ namespace _8beatMap
                     if ((i - timesig.StartTick) % (timesig.Numerator * 48 / timesig.Denominator) == 0) // bars
                     {
                         Grfx.FillRectangle(BarLineBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 3, width, 3);
-                        if (!DrawBarNumsAfter) Grfx.DrawString((i / 48 + 1).ToString(), BarNumFont, BarTextBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 4 - (int)Math.Round(BarNumSize));
+                        if (!DrawBarNumsAfter) Grfx.DrawString((timesig.StartBar + (i - timesig.StartTick) / (timesig.Numerator * 48 / timesig.Denominator) + 1).ToString(), BarNumFont, BarTextBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 4 - (int)Math.Round(BarNumSize));
                     }
                     else if ((i - timesig.StartTick) % (48 / timesig.Denominator) == 0) // notes of denominator length -- 48 = one whole note (four quarters)
                     {
@@ -255,7 +255,7 @@ namespace _8beatMap
                     if ((i - timesig.StartTick) % (timesig.Numerator * 48 / timesig.Denominator) == 0)
                     {
                         // draw bar number after all notes to avoid rendering issue when over holds
-                        Grfx.DrawString((i / 48 + 1).ToString(), BarNumFont, BarTextBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 4 - (int)Math.Round(BarNumSize));
+                        Grfx.DrawString((timesig.StartBar + (i - timesig.StartTick) / (timesig.Numerator * 48 / timesig.Denominator) + 1).ToString(), BarNumFont, BarTextBrush, 0, height - (float)(i - startTick + ShiftYTicks) * tickHeight - 4 - (int)Math.Round(BarNumSize));
                     }
                 }
             }
@@ -1050,7 +1050,8 @@ namespace _8beatMap
                 {
                     if (key == Keys.C)
                     {
-                        int copylen = (int)(48 * CopyLengthBox.Value);
+                        Notedata.TimeSigChange timesig = chart.GetTimeSigForTick((int)CurrentTick);
+                        int copylen = (int)((timesig.Numerator * 48 / timesig.Denominator) * CopyLengthBox.Value);
                         if ((int)CurrentTick + copylen >= chart.Length) copylen = chart.Length - (int)CurrentTick;
 
                         Notedata.Tick[] copydata = new Notedata.Tick[copylen];

--- a/8beatMap/Form1.cs
+++ b/8beatMap/Form1.cs
@@ -832,14 +832,22 @@ namespace _8beatMap
 
         private void ResizeBtn_Click(object sender, EventArgs e)
         {
-            Notedata.TimeSigChange lastticktimesig = chart.GetTimeSigForTick(chart.Length - 1);
-            while (lastticktimesig.StartBar > (int)ResizeBox.Value) // just skip bars we don't care about
+            int tries = 6; // using a fixed number of iterations saves us from having to check somehow, and ensures we won't hang from rounding errors
+            int newlen = chart.Length;
+            while (tries > 0)
             {
-                lastticktimesig = chart.GetTimeSigForTick(lastticktimesig.StartTick - 1);
+                Notedata.TimeSigChange lastticktimesig = chart.GetTimeSigForTick(newlen);
+                while (lastticktimesig.StartBar > (int)ResizeBox.Value) // just skip bars we don't care about
+                {
+                    lastticktimesig = chart.GetTimeSigForTick(lastticktimesig.StartTick - 1);
+                }
+
+                newlen = lastticktimesig.StartTick + ((int)ResizeBox.Value - lastticktimesig.StartBar) * (lastticktimesig.Numerator * 48 / lastticktimesig.Denominator); // tick last timesig change is at + how many extra bars after that * bar length
+                tries--;
             }
 
             //ResizeChart((int)ResizeBox.Value * 48);
-            ResizeChart(lastticktimesig.StartTick + ((int)ResizeBox.Value - lastticktimesig.StartBar) * (lastticktimesig.Numerator * 48 / lastticktimesig.Denominator)); // tick last timesig change is at + how many extra bars after that * bar length
+            ResizeChart(newlen);
             UpdateChart();
         }
 

--- a/8beatMap/Form1.cs
+++ b/8beatMap/Form1.cs
@@ -361,7 +361,11 @@ namespace _8beatMap
         {
             ChartScrollBar.Minimum = 0;
             ChartScrollBar.Maximum = (int)(chart.Length * TickHeight + IconHeight / 2 + 110);
-            ChartScrollBar.Value = (int)(chart.Length * TickHeight - CurrentTick * TickHeight);
+
+            int newval = (int)(chart.Length * TickHeight - CurrentTick * TickHeight);
+            if (newval < ChartScrollBar.Minimum) newval = ChartScrollBar.Minimum;
+            else if (newval > ChartScrollBar.Maximum) newval = ChartScrollBar.Maximum;
+            ChartScrollBar.Value = newval;
         }
 
 

--- a/8beatMap/Notedata.cs
+++ b/8beatMap/Notedata.cs
@@ -61,8 +61,9 @@ namespace _8beatMap
         public struct TimeSigChange
         {
             public int StartTick;
+            public int StartBar;
             public int Numerator; // numerator: number of notes (length = 1/denominator) in a bar
-            public int Denominator; // denominator: base note length (remember that 12 ticks is always a quarter note)
+            public int Denominator; // denominator: base note length (remember that 12 ticks is always a quarter note) -- denominators above 48 will cause crashes, and ones that aren't a factor of 48 will be weird
         }
 
         public struct Chart
@@ -389,7 +390,7 @@ namespace _8beatMap
                     }
                 }
 
-                return new TimeSigChange { StartTick = 0, Numerator = 4, Denominator = 4 }; // fallback
+                return new TimeSigChange { StartTick = 0, StartBar = 0, Numerator = 4, Denominator = 4 }; // fallback
             }
 
 

--- a/8beatMap/Notedata.cs
+++ b/8beatMap/Notedata.cs
@@ -619,7 +619,7 @@ namespace _8beatMap
             return i;
         }
 
-        private static string GetTimesigChangeString(TimeSigChange[] timesigs)
+        private static string MakeTimesigChangesString(TimeSigChange[] timesigs)
         {
             string ret = "";
 
@@ -635,7 +635,7 @@ namespace _8beatMap
             return ret;
         }
 
-        private static TimeSigChange[] GetTimesigChangesFromString(string str)
+        private static TimeSigChange[] ReadTimesigChangesFromString(string str)
         {
             if (str.Length == 0) return null;
 
@@ -677,7 +677,7 @@ namespace _8beatMap
                 {
                     try
                     {
-                        chart.TimeSigChanges = GetTimesigChangesFromString(tickObj[0].BUTTON3);
+                        chart.TimeSigChanges = ReadTimesigChangesFromString(tickObj[0].BUTTON3);
                     }
                     catch
                     { }
@@ -691,7 +691,7 @@ namespace _8beatMap
                 {
                     try
                     {
-                        chart.TimeSigChanges = GetTimesigChangesFromString(tickObj[0].B3);
+                        chart.TimeSigChanges = ReadTimesigChangesFromString(tickObj[0].B3);
                     }
                     catch
                     { }
@@ -756,7 +756,7 @@ namespace _8beatMap
 
             return JsonConvert.SerializeObject(tickObj).Replace("null", "\"\"").Replace(":0", ":\"\"") // empty/null should be stored as empty string
                 .Replace("R\":\"\"", "R\":0").Replace("T\":\"\"", "T\":0") // convert baR/beaT 0 back to integer
-                .ReplaceFirst("\"BUTTON1\":\"\"", "\"BUTTON1\":\"" + chart.SongName + "\"").ReplaceFirst("\"BUTTON2\":\"\"", "\"BUTTON2\":\"" + chart.Author + "\""); // metadata
+                .ReplaceFirst("\"BUTTON1\":\"\"", "\"BUTTON1\":\"" + chart.SongName + "\"").ReplaceFirst("\"BUTTON2\":\"\"", "\"BUTTON2\":\"" + chart.Author + "\"").ReplaceFirst("\"BUTTON3\":\"\"", "\"BUTTON3\":\"" + MakeTimesigChangesString(chart.TimeSigChanges) + "\""); // metadata
         }
 
         public static String ConvertChartToJson_Small(Chart chart)
@@ -797,7 +797,7 @@ namespace _8beatMap
 
             return JsonConvert.SerializeObject(tickObj).Replace("null", "\"\"").Replace(":0", ":\"\"") // empty/null should be stored as empty string
                 .Replace("R\":\"\"", "R\":0").Replace("T\":\"\"", "T\":0") // convert baR/beaT 0 back to integer
-                .ReplaceFirst("\"BUTTON1\":\"\"", "\"BUTTON1\":\"" + chart.SongName + "\"").ReplaceFirst("\"BUTTON2\":\"\"", "\"BUTTON2\":\"" + chart.Author + "\""); // metadata
+                .ReplaceFirst("\"BUTTON1\":\"\"", "\"BUTTON1\":\"" + chart.SongName + "\"").ReplaceFirst("\"BUTTON2\":\"\"", "\"BUTTON2\":\"" + chart.Author + "\"").ReplaceFirst("\"BUTTON3\":\"\"", "\"BUTTON3\":\"" + MakeTimesigChangesString(chart.TimeSigChanges) + "\""); // metadata
         }
     }
 }

--- a/8beatMap/Notedata.cs
+++ b/8beatMap/Notedata.cs
@@ -58,6 +58,13 @@ namespace _8beatMap
         }
 
 
+        public struct TimeSigChange
+        {
+            public int StartTick;
+            public int Numerator; // numerator: number of notes (length = 1/denominator) in a bar
+            public int Denominator; // denominator: base note length (remember that 12 ticks is always a quarter note)
+        }
+
         public struct Chart
         {
             private string ChartName;
@@ -266,6 +273,7 @@ namespace _8beatMap
 
             public double BPM;
 
+            public TimeSigChange[] TimeSigChanges;
 
 
             private bool[,] UsedSwipes;
@@ -369,6 +377,19 @@ namespace _8beatMap
             public double ConvertTimeToTicks(TimeSpan time)
             {
                 return time.TotalSeconds / (double)(5 / BPM);
+            }
+
+            public TimeSigChange GetTimeSigForTick(int tick)
+            {
+                if (TimeSigChanges != null)
+                {
+                    foreach (TimeSigChange sig in TimeSigChanges)
+                    {
+                        if (sig.StartTick <= tick) return sig;
+                    }
+                }
+
+                return new TimeSigChange { StartTick = 0, Numerator = 4, Denominator = 4 }; // fallback
             }
 
 
@@ -522,6 +543,7 @@ namespace _8beatMap
                 this.BPM = BPM;
                 UsedSwipes = null;
                 ChartFilePath = null;
+                TimeSigChanges = null;
             }
         }
 


### PR DESCRIPTION
While the base chart format seems to imply 4/4 (bars are always 4*BPM unit), there's no reason why we can't draw the note lines differently to what is implied by it.

This branch allows arbitrary time signatures, and the time signature can be changed at certain points in the song (with arbitrary bar number for restart) using the BUTTON3 header in chart json. ("[barnumtoshow1],[changetick1],[numerator1],[denominator1];[barnumtoshow2],[changetick2],[numerator2],[denominator2]...") *note that these bar numbers are zero-based, not one-based*

Chart length adjustments and copy length have been modified to make them function correctly.